### PR TITLE
Help to troubleshoot installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ disabled.
 First verify that [Neomake] is installed. Neomake Autolint depends on Neomake
 so if it is not installed Neomake Autolint will not work.
 
+Neomake Autolint needs to be installed as a plugin to Neomake. If Neomake was
+installed first, it may need to be uninstalled and reinstalled with Autolint. This
+is the case with vim-plug. Simply appending ` | Plug 'dojoteef/neomake-autolint' `
+to `Plug 'neomake/neomake'` and running `:PlugInstall` will **not** produce a working
+installation.
+
 Check if your version of vim supports jobs and timers. You can verify this by
 typing: `:echo has('nvim') || has('job') && has('timers')`
 

--- a/doc/neomake-autolint.txt
+++ b/doc/neomake-autolint.txt
@@ -73,6 +73,12 @@ First verify that Neomake (https://github.com/neomake/neomake) is installed.
 Neomake Autolint depends on Neomake so if it is not installed Neomake Autolint
 will not work.
 
+Additionally, Neomake Autolint needs to be installed as a plugin to Neomake. If Neomake was
+installed first, it may need to be uninstalled and reinstalled with Autolint. This
+is the case with vim-plug. Simply appending ` | Plug 'dojoteef/neomake-autolint' `
+to `Plug 'neomake/neomake'` and running `:PlugInstall` will **not** produce a working
+installation.
+
 Check if your version of vim supports jobs, see |job-control| and
 |timer_start()|. You can verify
 this by typing: >


### PR DESCRIPTION
I wanted to help others get up and running with this plugin. I was using Neomake first, then attempted the installation with vim-plug. However, without cleaning my previous Neomake installation, Autolint would not work. This was confusing, because I could access the help, variables, and temp directory where autolint was saving my edits. Sometime in the last hour I thought to do a clean and re-install. Success! Hopefully this bit of documentation can help someone else out too.

Thanks for the awesome plugin.
-al